### PR TITLE
Fixed typo preventing IdTokenResponse class import

### DIFF
--- a/src/IdTokenResponse.php
+++ b/src/IdTokenResponse.php
@@ -52,7 +52,7 @@ class IdTokenResponse extends BearerTokenResponse
             ->issuedBy('https://' . $_SERVER['HTTP_HOST'])
             ->issuedAt($dateTimeImmutableObject)
             ->expiresAt($dateTimeImmutableObject->setTimestamp(
-                $accessToken->getExpiryDateTime()->getTimestamp(),
+                $accessToken->getExpiryDateTime()->getTimestamp()
             ))
             ->relatedTo($userEntity->getIdentifier());
 


### PR DESCRIPTION
Hi, I found small typo when trying to run your fork. I found this typo when importing IdTokenResponse and extending from it. It's preventing to import IdTokenResponse class. Hope it helps even it is small change :). 